### PR TITLE
Feat/page route

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="https://fonts.cdnfonts.com/css/futura-std-4" rel="stylesheet">
+    <link href="https://fonts.cdnfonts.com/css/futura-pt" rel="stylesheet">
     <link href="https://fonts.cdnfonts.com/css/satoshi" rel="stylesheet">
     <title>Vite + React</title>
   </head>

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -44,6 +44,9 @@ export const Layout = ({ children }) => {
 const Container = styled.div`
   min-width: 360px;
   width: 100%;
+  & > main {
+    z-index: 0;
+  }
 `;
 const Header = styled.header`
   display: flex;

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -5,6 +5,7 @@ import Logo from "../../assets/icon/icon-logo--text.svg?react";
 import Menu from "../../assets/icon/icon-menu.svg?react";
 // components
 import { Nav } from "./Nav";
+import { NavCells } from "./NavCells";
 
 export const Layout = ({ children }) => {
   const [isNavOpen, setIsNavOpen] = useState(false);
@@ -33,7 +34,7 @@ export const Layout = ({ children }) => {
           <div onClick={() => setIsNavOpen((prev) => !prev)}>
             <Menu />
           </div>
-          {isNavOpen && <Nav setNavOpen={setIsNavOpen} />}
+          {isNavOpen && <Nav><NavCells setNavOpen={setIsNavOpen}/></Nav>}
         </div>
       </Header>
       <main>{children}</main>

--- a/src/components/layout/Nav.jsx
+++ b/src/components/layout/Nav.jsx
@@ -23,9 +23,10 @@ export const Nav = ({setNavOpen}) => {
 
   const handleOnClick = (path) => {
     navigate(path);
+    setEnterIndex(0);
     setNavOpen(false);
   };
-  
+  console.log(enterIndex);
   return (
     <Container onMouseLeave={() => handleMouseLeave()}>
       <NavCell>
@@ -125,7 +126,7 @@ export const Nav = ({setNavOpen}) => {
 
 const Container = styled.nav`
   position: absolute;
-
+  z-index: 10;
   background-color: ${(props) => props.theme.color.white};
   border-radius: 12px;
   border: none;

--- a/src/components/layout/Nav.jsx
+++ b/src/components/layout/Nav.jsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 // style
 import styled from "styled-components";
 import Logo from "@assets/icon/icon-logo--img.svg?react";
@@ -8,11 +8,13 @@ import Eezy from "@assets/icon/icon-eezy--small.svg?react";
 import Search from "@assets/icon/icon-search--small.svg?react";
 import Squeeze from "@assets/icon/icon-squeeze--small.svg?react";
 import Titmetable from "@assets/icon/icon-timetable--small.svg?react";
+import { p } from "framer-motion/client";
 
-export const Nav = ({setNavOpen}) => {
+export const Nav = ({ setNavOpen }) => {
   const [userName, setUserName] = useState("UserName");
   const [enterIndex, setEnterIndex] = useState(0);
   const navigate = useNavigate();
+  const locate = useLocation();
 
   const handleMouseEnter = (index) => {
     setEnterIndex(index);
@@ -22,11 +24,12 @@ export const Nav = ({setNavOpen}) => {
   };
 
   const handleOnClick = (path) => {
+    if(path === locate.pathname) return;
     navigate(path);
     setEnterIndex(0);
     setNavOpen(false);
   };
-  console.log(enterIndex);
+
   return (
     <Container onMouseLeave={() => handleMouseLeave()}>
       <NavCell>
@@ -39,15 +42,31 @@ export const Nav = ({setNavOpen}) => {
         onMouseEnter={() => handleMouseEnter(1)}
         onMouseLeave={() => handleMouseLeave()}
         onClick={() => handleOnClick("/user")}
-        style={{ backgroundColor: enterIndex === 1 ? "#F0F0F0" : "" }}
+        style={{
+          backgroundColor:
+            enterIndex === 1 || locate.pathname.startsWith("/user")
+              ? "#F0F0F0"
+              : "",
+        }}
       >
         <Titmetable
           width={16}
           height={16}
-          fill={enterIndex === 1 ? "#1C1B1F" : "#808080"}
+          fill={
+            enterIndex === 1 || locate.pathname.startsWith("/user")
+              ? "#1C1B1F"
+              : "#808080"
+          }
         />
         <div>
-          <span style={{ color: enterIndex === 1 ? "#000000" : "" }}>
+          <span
+            style={{
+              color:
+                enterIndex === 1 || locate.pathname.startsWith("/user")
+                  ? "#000000"
+                  : "",
+            }}
+          >
             Your Squeezy
           </span>
         </div>
@@ -56,15 +75,31 @@ export const Nav = ({setNavOpen}) => {
         onMouseEnter={() => handleMouseEnter(2)}
         onMouseLeave={() => handleMouseLeave()}
         onClick={() => handleOnClick("/squeeze")}
-        style={{ backgroundColor: enterIndex === 2 ? "#F0F0F0" : "" }}
+        style={{
+          backgroundColor:
+            enterIndex === 2 || locate.pathname.startsWith("/squeeze")
+              ? "#F0F0F0"
+              : "",
+        }}
       >
         <Squeeze
           width={16}
           height={16}
-          fill={enterIndex === 2 ? "#1C1B1F" : "#808080"}
+          fill={
+            enterIndex === 2 || locate.pathname.startsWith("/squeeze")
+              ? "#1C1B1F"
+              : "#808080"
+          }
         />
         <div>
-          <span style={{ color: enterIndex === 2 ? "#000000" : "" }}>
+          <span
+            style={{
+              color:
+                enterIndex === 2 || locate.pathname.startsWith("/squeeze")
+                  ? "#000000"
+                  : "",
+            }}
+          >
             squeeze
           </span>
           <span>categorize current tabs</span>
@@ -74,15 +109,33 @@ export const Nav = ({setNavOpen}) => {
         onMouseEnter={() => handleMouseEnter(3)}
         onMouseLeave={() => handleMouseLeave()}
         onClick={() => handleOnClick("/eezy")}
-        style={{ backgroundColor: enterIndex === 3 ? "#F0F0F0" : "" }}
+        style={{
+          backgroundColor:
+            enterIndex === 3 || locate.pathname.startsWith("/eezy")
+              ? "#F0F0F0"
+              : "",
+        }}
       >
         <Eezy
           width={16}
           height={16}
-          fill={enterIndex === 3 ? "#1C1B1F" : "#808080"}
+          fill={
+            enterIndex === 3 || locate.pathname.startsWith("/eezy")
+              ? "#1C1B1F"
+              : "#808080"
+          }
         />
         <div>
-          <span style={{ color: enterIndex === 3 ? "#000000" : "" }}>eezy</span>
+          <span
+            style={{
+              color:
+                enterIndex === 3 || locate.pathname.startsWith("/eezy")
+                  ? "#000000"
+                  : "",
+            }}
+          >
+            eezy
+          </span>
           <span>summarize this page</span>
         </div>
       </NavCell>
@@ -90,15 +143,31 @@ export const Nav = ({setNavOpen}) => {
         onMouseEnter={() => handleMouseEnter(4)}
         onMouseLeave={() => handleMouseLeave()}
         onClick={() => handleOnClick("/search")}
-        style={{ backgroundColor: enterIndex === 4 ? "#F0F0F0" : "" }}
+        style={{
+          backgroundColor:
+            enterIndex === 4 || locate.pathname.startsWith("/search")
+              ? "#F0F0F0"
+              : "",
+        }}
       >
         <Search
           width={16}
           height={16}
-          fill={enterIndex === 4 ? "#1C1B1F" : "#808080"}
+          fill={
+            enterIndex === 4 || locate.pathname.startsWith("/search")
+              ? "#1C1B1F"
+              : "#808080"
+          }
         />
         <div>
-          <span style={{ color: enterIndex === 4 ? "#000000" : "" }}>
+          <span
+            style={{
+              color:
+                enterIndex === 4 || locate.pathname.startsWith("/search")
+                  ? "#000000"
+                  : "",
+            }}
+          >
             Search
           </span>
         </div>
@@ -107,15 +176,31 @@ export const Nav = ({setNavOpen}) => {
         onMouseEnter={() => handleMouseEnter(5)}
         onMouseLeave={() => handleMouseLeave()}
         onClick={() => handleOnClick("/account")}
-        style={{ backgroundColor: enterIndex === 5 ? "#F0F0F0" : "" }}
+        style={{
+          backgroundColor:
+            enterIndex === 5 || locate.pathname.startsWith("/account")
+              ? "#F0F0F0"
+              : "",
+        }}
       >
         <Account
           width={16}
           height={16}
-          fill={enterIndex === 5 ? "#1C1B1F" : "#808080"}
+          fill={
+            enterIndex === 5 || locate.pathname.startsWith("/account")
+              ? "#1C1B1F"
+              : "#808080"
+          }
         />
         <div>
-          <span style={{ color: enterIndex === 5 ? "#000000" : "" }}>
+          <span
+            style={{
+              color:
+                enterIndex === 5 || locate.pathname.startsWith("/account")
+                  ? "#000000"
+                  : "",
+            }}
+          >
             account
           </span>
         </div>

--- a/src/components/layout/Nav.jsx
+++ b/src/components/layout/Nav.jsx
@@ -1,210 +1,19 @@
-import { useEffect, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
-// style
+import { useState } from "react";
 import styled from "styled-components";
 import Logo from "@assets/icon/icon-logo--img.svg?react";
-import Account from "@assets/icon/icon-account--small.svg?react";
-import Eezy from "@assets/icon/icon-eezy--small.svg?react";
-import Search from "@assets/icon/icon-search--small.svg?react";
-import Squeeze from "@assets/icon/icon-squeeze--small.svg?react";
-import Titmetable from "@assets/icon/icon-timetable--small.svg?react";
-import { p } from "framer-motion/client";
 
-export const Nav = ({ setNavOpen }) => {
+export const Nav = ({children}) => {
   const [userName, setUserName] = useState("UserName");
-  const [enterIndex, setEnterIndex] = useState(0);
-  const navigate = useNavigate();
-  const locate = useLocation();
-
-  const handleMouseEnter = (index) => {
-    setEnterIndex(index);
-  };
-  const handleMouseLeave = () => {
-    setEnterIndex(0);
-  };
-
-  const handleOnClick = (path) => {
-    if(path === locate.pathname) return;
-    navigate(path);
-    setEnterIndex(0);
-    setNavOpen(false);
-  };
 
   return (
-    <Container onMouseLeave={() => handleMouseLeave()}>
+    <Container>
       <NavCell>
         <LogoCircle>
           <Logo width={20} height={20} />
         </LogoCircle>
         <UserSpan>{`Hello, ${userName}!`}</UserSpan>
       </NavCell>
-      <NavCell
-        onMouseEnter={() => handleMouseEnter(1)}
-        onMouseLeave={() => handleMouseLeave()}
-        onClick={() => handleOnClick("/user")}
-        style={{
-          backgroundColor:
-            enterIndex === 1 || locate.pathname.startsWith("/user")
-              ? "#F0F0F0"
-              : "",
-        }}
-      >
-        <Titmetable
-          width={16}
-          height={16}
-          fill={
-            enterIndex === 1 || locate.pathname.startsWith("/user")
-              ? "#1C1B1F"
-              : "#808080"
-          }
-        />
-        <div>
-          <span
-            style={{
-              color:
-                enterIndex === 1 || locate.pathname.startsWith("/user")
-                  ? "#000000"
-                  : "",
-            }}
-          >
-            Your Squeezy
-          </span>
-        </div>
-      </NavCell>
-      <NavCell
-        onMouseEnter={() => handleMouseEnter(2)}
-        onMouseLeave={() => handleMouseLeave()}
-        onClick={() => handleOnClick("/squeeze")}
-        style={{
-          backgroundColor:
-            enterIndex === 2 || locate.pathname.startsWith("/squeeze")
-              ? "#F0F0F0"
-              : "",
-        }}
-      >
-        <Squeeze
-          width={16}
-          height={16}
-          fill={
-            enterIndex === 2 || locate.pathname.startsWith("/squeeze")
-              ? "#1C1B1F"
-              : "#808080"
-          }
-        />
-        <div>
-          <span
-            style={{
-              color:
-                enterIndex === 2 || locate.pathname.startsWith("/squeeze")
-                  ? "#000000"
-                  : "",
-            }}
-          >
-            squeeze
-          </span>
-          <span>categorize current tabs</span>
-        </div>
-      </NavCell>
-      <NavCell
-        onMouseEnter={() => handleMouseEnter(3)}
-        onMouseLeave={() => handleMouseLeave()}
-        onClick={() => handleOnClick("/eezy")}
-        style={{
-          backgroundColor:
-            enterIndex === 3 || locate.pathname.startsWith("/eezy")
-              ? "#F0F0F0"
-              : "",
-        }}
-      >
-        <Eezy
-          width={16}
-          height={16}
-          fill={
-            enterIndex === 3 || locate.pathname.startsWith("/eezy")
-              ? "#1C1B1F"
-              : "#808080"
-          }
-        />
-        <div>
-          <span
-            style={{
-              color:
-                enterIndex === 3 || locate.pathname.startsWith("/eezy")
-                  ? "#000000"
-                  : "",
-            }}
-          >
-            eezy
-          </span>
-          <span>summarize this page</span>
-        </div>
-      </NavCell>
-      <NavCell
-        onMouseEnter={() => handleMouseEnter(4)}
-        onMouseLeave={() => handleMouseLeave()}
-        onClick={() => handleOnClick("/search")}
-        style={{
-          backgroundColor:
-            enterIndex === 4 || locate.pathname.startsWith("/search")
-              ? "#F0F0F0"
-              : "",
-        }}
-      >
-        <Search
-          width={16}
-          height={16}
-          fill={
-            enterIndex === 4 || locate.pathname.startsWith("/search")
-              ? "#1C1B1F"
-              : "#808080"
-          }
-        />
-        <div>
-          <span
-            style={{
-              color:
-                enterIndex === 4 || locate.pathname.startsWith("/search")
-                  ? "#000000"
-                  : "",
-            }}
-          >
-            Search
-          </span>
-        </div>
-      </NavCell>
-      <NavCell
-        onMouseEnter={() => handleMouseEnter(5)}
-        onMouseLeave={() => handleMouseLeave()}
-        onClick={() => handleOnClick("/account")}
-        style={{
-          backgroundColor:
-            enterIndex === 5 || locate.pathname.startsWith("/account")
-              ? "#F0F0F0"
-              : "",
-        }}
-      >
-        <Account
-          width={16}
-          height={16}
-          fill={
-            enterIndex === 5 || locate.pathname.startsWith("/account")
-              ? "#1C1B1F"
-              : "#808080"
-          }
-        />
-        <div>
-          <span
-            style={{
-              color:
-                enterIndex === 5 || locate.pathname.startsWith("/account")
-                  ? "#000000"
-                  : "",
-            }}
-          >
-            account
-          </span>
-        </div>
-      </NavCell>
+      {children}
     </Container>
   );
 };
@@ -234,21 +43,6 @@ const NavCell = styled.div`
   padding: 6px;
   gap: 10px;
   align-items: center;
-
-  & > div {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    & > span:last-child {
-      ${(props) => props.theme.typography.subDescription};
-      color: rgba(128, 128, 128, 0.6);
-    }
-    & > span:first-child {
-      ${(props) => props.theme.typography.h3};
-      font-weight: bold;
-      color: #808080;
-    }
-  }
 `;
 
 const LogoCircle = styled.div`

--- a/src/components/layout/NavCells.jsx
+++ b/src/components/layout/NavCells.jsx
@@ -1,0 +1,226 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+// style
+import styled from "styled-components";
+import Account from "@assets/icon/icon-account--small.svg?react";
+import Eezy from "@assets/icon/icon-eezy--small.svg?react";
+import Search from "@assets/icon/icon-search--small.svg?react";
+import Squeeze from "@assets/icon/icon-squeeze--small.svg?react";
+import Titmetable from "@assets/icon/icon-timetable--small.svg?react";
+
+export const NavCells = ({setNavOpen}) => {
+  const [enterIndex, setEnterIndex] = useState(0);
+  const navigate = useNavigate();
+  const locate = useLocation();
+
+  const handleMouseEnter = (index) => {
+    setEnterIndex(index);
+  };
+  const handleMouseLeave = () => {
+    setEnterIndex(0);
+  };
+
+  const handleOnClick = (path) => {
+    if (path === locate.pathname) return;
+    navigate(path);
+    setEnterIndex(0);
+    setNavOpen(false);
+  };
+  return (
+    <>
+      <NavCell
+        onMouseEnter={() => handleMouseEnter(1)}
+        onMouseLeave={() => handleMouseLeave()}
+        onClick={() => handleOnClick("/user")}
+        style={{
+          backgroundColor:
+            enterIndex === 1 || locate.pathname.startsWith("/user")
+              ? "#F0F0F0"
+              : "",
+        }}
+      >
+        <Titmetable
+          width={16}
+          height={16}
+          fill={
+            enterIndex === 1 || locate.pathname.startsWith("/user")
+              ? "#1C1B1F"
+              : "#808080"
+          }
+        />
+        <div>
+          <span
+            style={{
+              color:
+                enterIndex === 1 || locate.pathname.startsWith("/user")
+                  ? "#000000"
+                  : "",
+            }}
+          >
+            Your Squeezy
+          </span>
+        </div>
+      </NavCell>
+      <NavCell
+        onMouseEnter={() => handleMouseEnter(2)}
+        onMouseLeave={() => handleMouseLeave()}
+        onClick={() => handleOnClick("/squeeze")}
+        style={{
+          backgroundColor:
+            enterIndex === 2 || locate.pathname.startsWith("/squeeze")
+              ? "#F0F0F0"
+              : "",
+        }}
+      >
+        <Squeeze
+          width={16}
+          height={16}
+          fill={
+            enterIndex === 2 || locate.pathname.startsWith("/squeeze")
+              ? "#1C1B1F"
+              : "#808080"
+          }
+        />
+        <div>
+          <span
+            style={{
+              color:
+                enterIndex === 2 || locate.pathname.startsWith("/squeeze")
+                  ? "#000000"
+                  : "",
+            }}
+          >
+            squeeze
+          </span>
+          <span>categorize current tabs</span>
+        </div>
+      </NavCell>
+      <NavCell
+        onMouseEnter={() => handleMouseEnter(3)}
+        onMouseLeave={() => handleMouseLeave()}
+        onClick={() => handleOnClick("/eezy")}
+        style={{
+          backgroundColor:
+            enterIndex === 3 || locate.pathname.startsWith("/eezy")
+              ? "#F0F0F0"
+              : "",
+        }}
+      >
+        <Eezy
+          width={16}
+          height={16}
+          fill={
+            enterIndex === 3 || locate.pathname.startsWith("/eezy")
+              ? "#1C1B1F"
+              : "#808080"
+          }
+        />
+        <div>
+          <span
+            style={{
+              color:
+                enterIndex === 3 || locate.pathname.startsWith("/eezy")
+                  ? "#000000"
+                  : "",
+            }}
+          >
+            eezy
+          </span>
+          <span>summarize this page</span>
+        </div>
+      </NavCell>
+      <NavCell
+        onMouseEnter={() => handleMouseEnter(4)}
+        onMouseLeave={() => handleMouseLeave()}
+        onClick={() => handleOnClick("/search")}
+        style={{
+          backgroundColor:
+            enterIndex === 4 || locate.pathname.startsWith("/search")
+              ? "#F0F0F0"
+              : "",
+        }}
+      >
+        <Search
+          width={16}
+          height={16}
+          fill={
+            enterIndex === 4 || locate.pathname.startsWith("/search")
+              ? "#1C1B1F"
+              : "#808080"
+          }
+        />
+        <div>
+          <span
+            style={{
+              color:
+                enterIndex === 4 || locate.pathname.startsWith("/search")
+                  ? "#000000"
+                  : "",
+            }}
+          >
+            Search
+          </span>
+        </div>
+      </NavCell>
+      <NavCell
+        onMouseEnter={() => handleMouseEnter(5)}
+        onMouseLeave={() => handleMouseLeave()}
+        onClick={() => handleOnClick("/account")}
+        style={{
+          backgroundColor:
+            enterIndex === 5 || locate.pathname.startsWith("/account")
+              ? "#F0F0F0"
+              : "",
+        }}
+      >
+        <Account
+          width={16}
+          height={16}
+          fill={
+            enterIndex === 5 || locate.pathname.startsWith("/account")
+              ? "#1C1B1F"
+              : "#808080"
+          }
+        />
+        <div>
+          <span
+            style={{
+              color:
+                enterIndex === 5 || locate.pathname.startsWith("/account")
+                  ? "#000000"
+                  : "",
+            }}
+          >
+            account
+          </span>
+        </div>
+      </NavCell>
+    </>
+  );
+};
+
+const NavCell = styled.div`
+  height: 40px;
+  border-radius: 10px;
+  border: none;
+  display: flex;
+  padding: 6px;
+  gap: 10px;
+  align-items: center;
+
+  & > div {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    & > span:last-child {
+      ${(props) => props.theme.typography.subDescription};
+      color: rgba(128, 128, 128, 0.6);
+    }
+    & > span:first-child {
+      ${(props) => props.theme.typography.h3};
+      font-weight: bold;
+      color: #808080;
+    }
+  }
+`;
+

--- a/src/styles/globalStyle.js
+++ b/src/styles/globalStyle.js
@@ -8,6 +8,12 @@ const GlobalStyle = createGlobalStyle`
         font-family: 'Satoshi', sans-serif;
         box-sizing: border-box;
     }
+
+    html, body {
+        height: 100%;
+        background-color: #f5f5f5;
+    }
+    
     #slide-root {
         display: flex;
         flex-direction: column;
@@ -16,6 +22,6 @@ const GlobalStyle = createGlobalStyle`
 
         align-items: center;
     }
-`
+`;
 
 export default GlobalStyle;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -54,6 +54,7 @@ const color = {
     pressed : "#E85079"
   },
   white : "#FFFFFF",
+  black : "#000000",
 };
 
 export const theme = {

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,6 +1,6 @@
 const typography = {
   button : {
-    fontFamily : 'Futura Std',
+    fontFamily : 'Futura PT',
     fontSize : "14px",
     letterSpacing : "-6%",
   },
@@ -54,7 +54,6 @@ const color = {
     pressed : "#E85079"
   },
   white : "#FFFFFF",
-  black : "#000000",
 };
 
 export const theme = {


### PR DESCRIPTION
## What
이 pr은 SlidePanel 중 메뉴 아이콘을 클릭 했을 때 열리는 네비게이션 메뉴를 최상단에 위치하는 것과 렌더링을 효율적으로 하기 위한 컴포넌트 분리 및 기존 폰트의 style 차이로 인한 폰트 변경입니다.
아래의 변경 사항을 포함합니다.

-  Nav / NavCell 부모 및 자식 컴포넌트로 분리
- 메뉴가 열렸을 경우 선택을 위해 최상위 위치하도록 z-index를 추가했습니다.
- 기존 Layout으로 설정된 메뉴 클릭 시 개별 페이지로 이동
- 기존 위치에 해당하는 메뉴의 색상을 추가하고 이동할 수 없도록 추가
 + Futura-std -> Futura-pt 로 변경(글씨 크기 차이)
 + css theme 검정색 추가
 + 전체 슬라이드 영역 ffffff -> f5f5f5 로 색상을 변경하고 전체 크기를 잡도록 변경

## Why
메뉴 리스트를 호버하거나 선택할 경우 렌더링 시 관계 없는 프로필 이미지와 유저 이름이 반복 렌더링되는 문제를 해결하기 위해
현재 위치 메뉴 클릭 시 페이지 새로고침되는 문제를 막기 위해

## How to Test
1. npm run build
2. [크롬 확장 프로그램](chrome://extensions/)에서 dist 폴더 로드
3. 익스텐션 아이콘 클릭
4. 팝업의 squeeze or eezy 클릭
5. 선택된 타입에 해당하는 슬라이드가 열리는 지 확인
6. 메뉴 아이콘 클릭
7. 개별 메뉴 별 이동 시 원하는 페이지로 이동되는지 확인
8. 슬라이드 메뉴 선택 효과 확인

## Screenshots

<img width="355" alt="image" src="https://github.com/user-attachments/assets/e1aee6f0-86c6-4887-9443-9585d8fc6769">

## Additional Information
