### PR TITLE
Feat/user squeezy UI

### DIFF
--- a/src/assets/icon/icon-add--floatbtn.svg
+++ b/src/assets/icon/icon-add--floatbtn.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8 18V10H0V8H8V0H10V8H18V10H10V18H8Z" fill="#1C1B1F"/>
+</svg>

--- a/src/components/squeezy/SqueezyHistory.jsx
+++ b/src/components/squeezy/SqueezyHistory.jsx
@@ -1,0 +1,20 @@
+import styled from "styled-components";
+import { SqueezyList } from "./SqueezyList";
+
+export const SqueezyHistroy = () => {
+  return (
+    <Container>
+      <History>{`0 / 50 history`}</History>
+      <SqueezyList />
+    </Container>
+  );
+};
+
+const Container = styled.div``;
+
+const History = styled.span`
+  ${(props) => props.theme.typography.description};
+  color: #484848;
+
+  margin-top: 2px;
+`;

--- a/src/components/squeezy/SqueezyList.jsx
+++ b/src/components/squeezy/SqueezyList.jsx
@@ -1,0 +1,109 @@
+import styled from "styled-components";
+import Add from "@assets/icon/icon-add--floatbtn.svg?react";
+
+export const SqueezyList = () => {
+  return (
+    <Container>
+      <ViewTypeButtonWrap>
+        <ViewTypeButton
+          style={{ backgroundColor: "#3C3C3C", color: "#ffffff" }}
+        >
+          All
+        </ViewTypeButton>
+        <ViewTypeButton>eezy</ViewTypeButton>
+        <ViewTypeButton>squeeze</ViewTypeButton>
+      </ViewTypeButtonWrap>
+      <Content>
+        <FloatingButton>
+          <Add width={18} height={18} />
+        </FloatingButton>
+      </Content>
+      <PageIndex>
+        {[1, 2, 3, 4, 5].map((num) => {
+          return (
+            <PageIndexButton style={{ color: "#000000" }}>
+              {num}
+            </PageIndexButton>
+          );
+        })}
+      </PageIndex>
+      <Footer>
+        <span>squeeeeezy</span>
+      </Footer>
+    </Container>
+  );
+};
+
+const Container = styled.div``;
+
+const Content = styled.div`
+  margin-top: 9px;
+  height: 600px;
+  position: relative;
+`;
+
+const ViewTypeButtonWrap = styled.div`
+  display: flex;
+  gap: 4px;
+
+  margin-top: 9px;
+`;
+
+const ViewTypeButton = styled.button`
+  ${(props) => props.theme.typography.h3};
+  color: #6a6a6a;
+  background-color: transparent;
+
+  height: 28px;
+  padding: 4px 14px;
+  border: 1px solid #e8e8e8;
+  border-radius: 20px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const PageIndex = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+`;
+
+const PageIndexButton = styled.span`
+  border: none;
+  background-color: transparent;
+
+  ${(props) => props.theme.typography.h2};
+  color: rgba(0, 0, 0, 0.5);
+`;
+
+const FloatingButton = styled.button`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  margin-right: 10px;
+
+  width: 45px;
+  height: 45px;
+  background-color: #ffffff;
+  border: 1px solid #e4e4e4;
+  border-radius: 50%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Footer = styled.footer`
+  display: flex;
+  justify-content: center;
+  & > span {
+    ${(props) => props.theme.typography.button};
+    font-weight: bold;
+    letter-spacing: -4%;
+    color: rgba(0, 0, 0, 0.5);
+  }
+
+  margin-top: 10px;
+`;

--- a/src/pages/UserSqueezyPage.jsx
+++ b/src/pages/UserSqueezyPage.jsx
@@ -1,13 +1,23 @@
 import styled from "styled-components";
+import { SqueezyHistroy } from "@components/squeezy/SqueezyHistory";
 
 export const UserSqueezyPage = () => {
   return (
     <Container>
-      <h1>User Squeezy Page</h1>
+      <Header>Your Squeezy</Header>
+      <SqueezyHistroy />
     </Container>
   );
 };
 
 const Container = styled.div`
-  // CSS
+  padding: 9px 14px; // content 고정 padding
+
+  display: flex;
+  flex-direction: column;
+`;
+
+const Header = styled.header`
+  ${(props) => props.theme.typography.title};
+  color: ${(props) => props.theme.color.black};
 `;


### PR DESCRIPTION
## What
이 pr은 SlidePanel 중 메뉴 아이콘을 클릭 했을 때 열리는 네비게이션 메뉴 중 Your squeezy라는 메뉴를 클릭 했을 경우 나오는 화면에 해당하는 UI 설계입니다.
아래의 변경 사항을 포함합니다.

-  Nav / NavCell 부모 및 자식 컴포넌트로 분리
- SqueezyHistory와 SqueezyList를 통해 렌더링의 관계성이 있는 요소 두가지로 분할
- 카테고리, 페이지 인덱싱, 추가 버튼 ui

## Why
기능 연결을 위한 브랜치와 ui 개선을 위한 브랜치를 분리하기 위해

## How to Test
1. npm run build
2. [크롬 확장 프로그램](chrome://extensions/)에서 dist 폴더 로드
3. 익스텐션 아이콘 클릭
4. 팝업의 squeeze or eezy 클릭
5. 선택된 타입에 해당하는 슬라이드가 열리는 지 확인
6. 메뉴 아이콘 클릭
7. Your squeezy 메뉴 클릭
8. 화면 구성 확인

## Screenshots

<img width="532" alt="스크린샷 2024-11-05 오후 1 24 39" src="https://github.com/user-attachments/assets/e0b6ff69-d3b6-4a32-838c-9de8cfed9723">


## Additional Information
저장된 컨텐츠에 해당하는 eezy와 squeeze 내용은 해당 페이지에서의 내용을 공유하기 떄문에 추가하지 않았습니다