### PR TITLE
Feat/squeeze UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { RouterProvider } from "react-router";
 import { UserSqueezyPage } from "./pages/UserSqueezyPage";
 import { SearchPage } from "./pages/SearchPage";
 import { AccountPage } from "./pages/AccountPage";
+import { SqueezingPage } from "./pages/SqueezingPage";
 
 const router = createMemoryRouter([
   {
@@ -20,6 +21,14 @@ const router = createMemoryRouter([
     element: (
       <Layout>
         <SqueezePage />
+      </Layout>
+    ),
+  },
+  {
+    path : "/squeeze/squeezing",
+    element: (
+      <Layout>
+        <SqueezingPage />
       </Layout>
     ),
   },

--- a/src/assets/squeeze-folder--back.svg
+++ b/src/assets/squeeze-folder--back.svg
@@ -1,0 +1,18 @@
+<svg width="205" height="203" viewBox="0 0 205 203" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_94_1857)">
+<rect x="4" width="197" height="194.391" rx="18.2649" fill="#F9CF35"/>
+<rect x="4.65232" y="0.652318" width="195.695" height="193.086" rx="17.6126" stroke="#D7D7D7" stroke-width="1.30464"/>
+</g>
+<defs>
+<filter id="filter0_d_94_1857" x="0" y="0" width="205" height="202.391" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_94_1857"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_94_1857" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/assets/squeeze-folder--front.svg
+++ b/src/assets/squeeze-folder--front.svg
@@ -1,0 +1,14 @@
+<svg width="197" height="109" viewBox="0 0 197 109" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_b_579_322)">
+<path d="M0 0H34.8352C43.3422 0 51.4831 3.46144 57.3851 9.58809L67.5494 20.1392C73.4514 26.2658 81.5923 29.7273 90.0993 29.7273H197V90.7351C197 100.823 188.823 109 178.735 109H18.2649C8.17747 109 0 100.823 0 90.7351V0Z" fill="#F9CF35"/>
+<path d="M196.348 30.3796V90.7351C196.348 100.462 188.462 108.348 178.735 108.348H18.2649C8.53773 108.348 0.652318 100.462 0.652318 90.7351V0.652318H34.8352C43.165 0.652318 51.1363 4.04165 56.9153 10.0407L67.0796 20.5917C73.1046 26.846 81.415 30.3796 90.0993 30.3796H196.348Z" stroke="white" stroke-opacity="0.4" stroke-width="1.30464"/>
+</g>
+<defs>
+<filter id="filter0_b_579_322" x="-7.82781" y="-7.82781" width="212.656" height="124.656" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feGaussianBlur in="BackgroundImageFix" stdDeviation="3.91391"/>
+<feComposite in2="SourceAlpha" operator="in" result="effect1_backgroundBlur_579_322"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_579_322" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/src/components/squeeze/SqueezeItem.jsx
+++ b/src/components/squeeze/SqueezeItem.jsx
@@ -1,0 +1,65 @@
+import styled from "styled-components";
+import Icon from "@assets/icon/icon-squeeze--small.svg?react";
+import FolderBack from "@assets/squeeze-folder--back.svg?react";
+import FolderFront from "@assets/squeeze-folder--front.svg?react";
+
+export const SqueezeItem = ({
+  width = 197,
+  height = 194,
+  color = "#F9CF35",
+  title = "Title",
+  tabs = 0,
+  images = [],
+}) => {
+  return (
+    <Container width={width} height={height}>
+      <FolderBack width={width} height={height} fill={color} />
+      <FolderFront width={width} height={height / 1.8} fill={color} />
+      <div
+        style={{
+          width: `${width}px`,
+          height: `${height / 1.8}px`,
+          padding: `${width / 10}px ${height / 10}px`,
+        }}
+      >
+        <Icon width={width / 12} height={width / 12} />
+        <FolderSpan size={width / 12} color="rgba(0, 0, 0, 1)">
+          {title}
+        </FolderSpan>
+        <FolderSpan size={width / 12} color="rgba(0, 0, 0, 0.36)">
+          {tabs} tabs
+        </FolderSpan>
+      </div>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  position: relative;
+  z-index: 1;
+  width: ${(props) => props.width}px;
+  height: ${(props) => props.height}px;
+
+  & > svg:nth-child(2) {
+    position: absolute;
+    top: ${(props) => props.height / 2.5}px;
+    left: 0;
+    z-index: 2;
+  }
+  & > div {
+    z-index: 3;
+    position: absolute;
+    top: ${(props) => props.height / 2.5}px;
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+  }
+`;
+
+const FolderSpan = styled.span`
+  font-family: "Satoshi";
+  font-size: ${(props) => props.size}px;
+  font-weight: 500;
+  color: ${(props) => props.color};
+`;

--- a/src/pages/SqueezePage.jsx
+++ b/src/pages/SqueezePage.jsx
@@ -2,18 +2,20 @@ import styled from "styled-components";
 // img import
 import Logo from "@assets/icon/icon-logo--img.svg?react";
 import Squeeze from "@assets/icon/icon-squeeze--small.svg?react";
+import { useNavigate } from "react-router-dom";
 
 export const SqueezePage = () => {
+  const navigate = useNavigate();
   return (
     <Container>
       <Header>
         <ProfileCircle>
           <Logo width={20} height={20} />
         </ProfileCircle>
-        <span>Do you wanna squeeze current tabs</span>
+        <span>Do you wanna squeeze current tabs?</span>
       </Header>
       <SqueezeButtonContainer>
-        <SqueezeButton>
+        <SqueezeButton onClick={() => navigate('/squeeze/squeezing')}>
           <Squeeze width={42} height={42} />
           <div>
             <span>squeeze</span>

--- a/src/pages/SqueezePage.jsx
+++ b/src/pages/SqueezePage.jsx
@@ -1,13 +1,99 @@
 import styled from "styled-components";
+// img import
+import Logo from "@assets/icon/icon-logo--img.svg?react";
+import Squeeze from "@assets/icon/icon-squeeze--small.svg?react";
 
 export const SqueezePage = () => {
   return (
     <Container>
-      <h2>Squeeze Page</h2>
+      <Header>
+        <ProfileCircle>
+          <Logo width={20} height={20} />
+        </ProfileCircle>
+        <span>Do you wanna squeeze current tabs</span>
+      </Header>
+      <SqueezeButtonContainer>
+        <SqueezeButton>
+          <Squeeze width={42} height={42} />
+          <div>
+            <span>squeeze</span>
+            <span>categorize current tabs</span>
+          </div>
+        </SqueezeButton>
+      </SqueezeButtonContainer>
     </Container>
   );
 };
 
 const Container = styled.div`
-  // CSS 코드
+  padding: 9px 14px;
+`;
+
+const Header = styled.header`
+  display: flex;
+  gap: 14px;
+  align-items: center;
+
+  & > span {
+    ${(props) => props.theme.typography.h1};
+    font-weight: 500;
+    color: #484848;
+  }
+`;
+
+const ProfileCircle = styled.div`
+  width: 31px;
+  height: 31px;
+
+  background-color: ${(props) => props.theme.color.white};
+  border: 1px solid #d7d7d7;
+  border-radius: 50%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const SqueezeButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 24px;
+`;
+
+const SqueezeButton = styled.button`
+  padding: 11px;
+  display: flex;
+  gap: 11px;
+  align-items: center;
+
+  border: 1px solid #ffdb2b;
+  border-radius: 18px;
+  background-color: ${(props) => props.theme.color.yellow.default};
+
+  // active color
+  &:hover {
+    background-color: ${(props) => props.theme.color.yellow.hover};
+  }
+  &:active {
+    background-color: ${(props) => props.theme.color.yellow.pressed};
+  }
+  cursor: pointer;
+
+  //child
+  & > div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+
+    & > span:nth-child(1) {
+      ${(props) => props.theme.typography.button};
+      font-weight: 500;
+      color: #111111;
+    }
+    & > span:nth-child(2) {
+      ${(props) => props.theme.typography.description};
+      color: rgba(1, 1, 1, 0.6);
+    }
+  }
 `;

--- a/src/pages/SqueezingPage.jsx
+++ b/src/pages/SqueezingPage.jsx
@@ -1,0 +1,54 @@
+import styled from "styled-components";
+import Logo from "@assets/icon/icon-logo--img.svg?react";
+import { SqueezeItem } from "../components/squeeze/SqueezeItem";
+
+export const SqueezingPage = () => {
+  return (
+    <Container>
+      <Header>
+        <ProfileCircle>
+          <Logo width={20} height={20} />
+        </ProfileCircle>
+        <span>squeezing...</span>
+      </Header>
+      <SqueezeItem />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  padding: 9px 14px;
+
+  margin-top: 216px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const Header = styled.header`
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 12px;
+
+  & > span {
+    ${(props) => props.theme.typography.h1};
+    font-weight: 500;
+    color: #484848;
+  }
+`;
+
+const ProfileCircle = styled.div`
+  width: 31px;
+  height: 31px;
+
+  background-color: ${(props) => props.theme.color.white};
+  border: 1px solid #d7d7d7;
+  border-radius: 50%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+


### PR DESCRIPTION
## What
이 pr은 SlidePanel 중 메뉴 아이콘을 클릭 후 squeeze를 이동했을 경우 사용자가 마주할 화면 ui입니다.
아래의 변경 사항을 포함합니다.

-  squeezing page 추가를 통해 사용자 선택과 squeeze 기능을 처리할 영역 분리
- squeeze 폴더 재사용성을 높이기 위한 컴포넌트화

## Why
팝업에서 squeeze 클릭 시 squeezing 되어야함
history 등에서 squeeze 폴더를 다른 높이와 너비로 재사용되어야 함

## How to Test
1. npm run build
2. [크롬 확장 프로그램](chrome://extensions/)에서 dist 폴더 로드
3. 익스텐션 아이콘 클릭
4. 팝업의 squeeze or eezy 클릭
5. 선택된 타입에 해당하는 슬라이드가 열리는 지 확인
6. 메뉴 아이콘 클릭
7. squeeze 메뉴 클릭

## Screenshots

<img width="379" alt="image" src="https://github.com/user-attachments/assets/5a5d4f02-15ad-4727-889a-a3f3bb938289">
<img width="379" alt="스크린샷 2024-11-05 오후 7 09 07" src="https://github.com/user-attachments/assets/df6233b5-4514-43d7-a9f2-99ab60610dc0">

## Additional Information
