### PR TITLE
fix : 세부 페이지 이동 방지 (재수정)

### DIFF
--- a/src/components/layout/NavCells.jsx
+++ b/src/components/layout/NavCells.jsx
@@ -21,7 +21,7 @@ export const NavCells = ({setNavOpen}) => {
   };
 
   const handleOnClick = (path) => {
-    if (path.startsWith(locate.pathname)) return;
+    if (locate.pathname.startsWith(path)) return;
     navigate(path);
     setEnterIndex(0);
     setNavOpen(false);


### PR DESCRIPTION
## What
이 pr은 SlidePanel 중 메뉴 아이콘을 클릭 했을 때 열리는 네비게이션 메뉴 중 현재 위치한 페이지와 관련된 메뉴 클릭 방지 문제 수정입니다.
아래의 변경 사항을 포함합니다.

- 현재 페이지 주소 = route 주소와 같은지 -> route 주소로 시작하는지로 변경

## Why
세부 페이지 ex) /squeeze/squeezing 페이지에서 메뉴 클릭 시 기존 문제 통과 오류

## How to Test
1. npm run build
2. [크롬 확장 프로그램](chrome://extensions/)에서 dist 폴더 로드
3. 익스텐션 아이콘 클릭
4. 팝업의 squeeze or eezy 클릭
5. 선택된 타입에 해당하는 슬라이드가 열리는 지 확인
6. 메뉴 아이콘 클릭
7. 세부 페이지 이동 후 메뉴 클릭

## Screenshots
## Additional Information
