### PR TITLE
Feat/eezy UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,16 @@
 import { createMemoryRouter } from "react-router-dom";
+import { RouterProvider } from "react-router";
 // components
 import { Layout } from "@components/layout/Layout";
 // pages
 import { EezyPage } from "@pages/EezyPage";
 import { LoginPage } from "@pages/LoginPage";
 import { SqueezePage } from "@pages/SqueezePage";
-import { RouterProvider } from "react-router";
-import { UserSqueezyPage } from "./pages/UserSqueezyPage";
-import { SearchPage } from "./pages/SearchPage";
-import { AccountPage } from "./pages/AccountPage";
-import { SqueezingPage } from "./pages/SqueezingPage";
+import { UserSqueezyPage } from "@pages/UserSqueezyPage";
+import { SearchPage } from "@pages/SearchPage";
+import { AccountPage } from "@pages/AccountPage";
+import { SqueezingPage } from "@pages/SqueezingPage";
+import { EezingPage } from "@pages/EezingPage";
 
 const router = createMemoryRouter([
   {
@@ -39,6 +40,14 @@ const router = createMemoryRouter([
         <EezyPage />
       </Layout>
     ),
+  },
+  {
+    path: "/eezy/eezying",
+    element : (
+      <Layout>
+        <EezingPage />
+      </Layout>
+    )
   },
   {
     path: "/user",

--- a/src/components/eezy/EezyItem.jsx
+++ b/src/components/eezy/EezyItem.jsx
@@ -1,0 +1,56 @@
+import styled from "styled-components";
+import Eezy from "@assets/icon/icon-eezy--small.svg?react";
+
+export const EezyItem = ({ data = { title: "Exporing UI Design" } }) => {
+  return (
+    <Container>
+      <Title>
+        <Eezy />
+        <span>{data.title}</span>
+      </Title>
+      <Content>
+        <span>SubTitle</span>
+        <span>content</span>
+      </Content>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  padding: 12px 18px;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+
+  border: 1px solid #d7d7d7;
+  border-radius: 16px;
+`;
+
+const Title = styled.div`
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  & > span {
+    ${(props) => props.theme.typography.title};
+    color: #000000;
+  }
+`;
+
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+
+  & > span:first-child {
+    ${(props) => props.theme.typography.h2};
+    color: #484848;
+    font-weight: 500;
+  }
+  & > span:last-child {
+    padding: 0px 0px 0px 16px;
+    border-left: 5px solid #fa99b3;
+    ${(props) => props.theme.typography.h2};
+    color: #000000;
+  }
+`;

--- a/src/components/eezy/EezySmallItem.jsx
+++ b/src/components/eezy/EezySmallItem.jsx
@@ -1,0 +1,108 @@
+import styled from "styled-components";
+
+import Eezy from "@assets/icon/icon-eezy--small.svg?react";
+
+export const EezySmallItem = () => {
+  const truncate = (str, n) => {
+    return str?.length > n ? str.substr(0, n - 1) + "..." : str;
+  };
+  return (
+    <Container>
+      <Context>
+        <Title>Exporing Ui Design</Title>
+        <Content>
+          <span>Abstract</span>
+          <div>
+            The document titled "Explore | Layers" promotes a platform for
+            designers, emphasizing its functionally in allowing user to share
+            work, connect with peers in the industry
+          </div>
+          <Blur></Blur>
+        </Content>
+      </Context>
+      <Link>
+        <PageName>
+          <Eezy width={16} height={16} />
+          <span>Pinterest</span>
+        </PageName>
+        <span>https://www.pinterest/pinterest</span>
+      </Link>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 158px;
+  height: 245px;
+
+  background-color: #ffffff;
+
+  display: flex;
+  flex-direction: column;
+
+  border: 1px solid #d7d7d7;
+  border-radius: 14px;
+  overflow-y: hidden;
+`;
+
+const Title = styled.span`
+  ${(props) => props.theme.typography.h3};
+  color: #000000;
+  font-weight: 500;
+`;
+
+const PageName = styled.div`
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  & > span {
+    ${(props) => props.theme.typography.h3};
+    font-weight: 500;
+    color: #000000;
+  }
+`;
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  gap: 12px;
+  & > span,
+  div {
+    ${(props) => props.theme.typography.description};
+    color: #858585;
+  }
+  & > div {
+    height: 128px;
+    border-left: 5px solid #fa99b3;
+    padding: 0px 0px 0px 12px;
+    line-height: 165%;
+  }
+`;
+const Link = styled.div`
+  padding: 9px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+
+  & > span {
+    ${(props) => props.theme.typography.subDescription};
+    color: #858585;
+  }
+`;
+
+const Context = styled.div`
+  padding: 14px 12px 0px 12px;
+  border-bottom: 1px solid #d7d7d7;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const Blur = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 45px;
+  bottom: 0;
+  background: linear-gradient(to top, #ffffff, rgba(255, 255, 255, 0));
+  z-index: 1;
+`;

--- a/src/pages/EezingPage.jsx
+++ b/src/pages/EezingPage.jsx
@@ -1,0 +1,49 @@
+import styled from "styled-components";
+import Logo from "@assets/icon/icon-logo--img.svg?react";
+import { EezyItem } from "@components/eezy/EezyItem";
+
+export const EezingPage = () => {
+    return (<Container>
+        <Header>
+            <ProfileCircle>
+                <Logo width={20} height={20} />
+            </ProfileCircle>
+            <span>eezing...</span>
+        </Header>
+        <EezyItem />
+    </Container>)
+};
+
+const Container = styled.div`
+  padding: 9px 14px;
+`;
+
+const Header = styled.header`
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  margin-bottom: 18px;
+
+  & > span {
+    ${(props) => props.theme.typography.h1};
+    font-weight: 500;
+    color: #484848;
+  }
+`;
+
+const ProfileCircle = styled.div`
+  width: 31px;
+  height: 31px;
+
+  background-color: ${(props) => props.theme.color.white};
+  border: 1px solid #d7d7d7;
+  border-radius: 50%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Content = styled.div`
+
+`;

--- a/src/pages/EezyPage.jsx
+++ b/src/pages/EezyPage.jsx
@@ -1,13 +1,101 @@
 import styled from "styled-components";
+// img import
+import Logo from "@assets/icon/icon-logo--img.svg?react";
+import Eezy from "@assets/icon/icon-eezy--small.svg?react";
+import { useNavigate } from "react-router-dom";
 
 export const EezyPage = () => {
+  const navigate = useNavigate();
   return (
     <Container>
-      <h1>Eeazy Page</h1>
+      <Header>
+        <ProfileCircle>
+          <Logo width={20} height={20} />
+        </ProfileCircle>
+        <span>Do you wanna eezy current tabs?</span>
+      </Header>
+      <SqueezeButtonContainer>
+        <SqueezeButton onClick={() => navigate('/eezy/eezying')}>
+          <Eezy width={42} height={42} />
+          <div>
+            <span>eezy</span>
+            <span>summarize this page</span>
+          </div>
+        </SqueezeButton>
+      </SqueezeButtonContainer>
     </Container>
   );
 };
 
 const Container = styled.div`
-  // CSS
+  padding: 9px 14px;
+`;
+
+const Header = styled.header`
+  display: flex;
+  gap: 14px;
+  align-items: center;
+
+  & > span {
+    ${(props) => props.theme.typography.h1};
+    font-weight: 500;
+    color: #484848;
+  }
+`;
+
+const ProfileCircle = styled.div`
+  width: 31px;
+  height: 31px;
+
+  background-color: ${(props) => props.theme.color.white};
+  border: 1px solid #d7d7d7;
+  border-radius: 50%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const SqueezeButtonContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 24px;
+`;
+
+const SqueezeButton = styled.button`
+  padding: 11px;
+  display: flex;
+  gap: 11px;
+  align-items: center;
+
+  border: 1px solid #F485A3;
+  border-radius: 18px;
+  background-color: ${(props) => props.theme.color.pink.default};
+
+  // active color
+  &:hover {
+    background-color: ${(props) => props.theme.color.pink.hover};
+  }
+  &:active {
+    background-color: ${(props) => props.theme.color.pink.pressed};
+  }
+  cursor: pointer;
+
+  //child
+  & > div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+
+    & > span:nth-child(1) {
+      ${(props) => props.theme.typography.button};
+      font-weight: 500;
+      color: #111111;
+    }
+    & > span:nth-child(2) {
+      ${(props) => props.theme.typography.description};
+      color: rgba(1, 1, 1, 0.6);
+    }
+  }
 `;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -7,7 +7,7 @@ const typography = {
   title : {
     fontFamily : "Satoshi",
     fontSize : "20px",
-    fontWeight : "bold",
+    fontWeight : 500,
     letterSpacing : "-6%",
   },
   h1 : {
@@ -31,7 +31,7 @@ const typography = {
   description : {
     fontFamily : "Satoshi",
     fontSize : "10px",
-    fontWeight : "bold",
+    fontWeight : 500,
     letterSpacing : "-6%",
   },
   subDescription : {


### PR DESCRIPTION
## What
Eezy 페이지 사용자 선택 페이지와 기능 페이지의 ui입니다.
아래의 변경 사항을 포함합니다.

-  eezing page 추가를 통해 사용자 선택과 eezy 기능을 처리할 영역 분리
- eezy 폴더 재사용성을 높이기 위한 컴포넌트화

## Why
팝업에서 eezy 클릭 시 eezing 되어야함
history 등에서 squeeze 폴더를 다른 높이와 너비로 재사용되어야 함
- 기본 / 스몰형으로 구성

## How to Test
1. npm run build
2. [크롬 확장 프로그램](chrome://extensions/)에서 dist 폴더 로드
3. 익스텐션 아이콘 클릭
4. 팝업의 squeeze or eezy 클릭
5. 선택된 타입에 해당하는 슬라이드가 열리는 지 확인
6. 메뉴 아이콘 클릭
7. eezy 메뉴 클릭

## Screenshots
<img width="427" alt="image" src="https://github.com/user-attachments/assets/59fd9235-d798-4a93-9d28-ece37cac2da8">
<img width="434" alt="image" src="https://github.com/user-attachments/assets/57f446e8-4cb1-41f6-b904-7660c7c8dbd4">


## Additional Information
