### PR TITLE
Feat/eezy

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -93,23 +93,17 @@ function extractHtml() {
 }
 
 // 팝업의 버튼이 눌렸을 때의 preview.jsx/onSqueeze()의 메시지를 수신하기 위한 이벤트 리스너 등록
-chrome.runtime.onMessage.addListener(async (request) => {
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === "open_sidepanel") {
     try {
       if (request.type) {
-        await chrome.storage.local.set({ type: request.type });
+        chrome.storage.local.set({ type: request.type });
       }
-      /*
-      if (!homeAndGptWindow) {
-        await createHomeAndGptWindow(); // ChatGPT 및 landing.html 창 생성
-        // 기존 윈도우로 다시 포커스 이동
-        await chrome.windows.update(currentWindowId, { focused: true });
-      } else if (!gptTab) {
-        await createGptTab(); // ChatGPT 탭이 없으면 생성
-      }*/
       openSidePanel(); // 사이드 패널 열기
+      sendResponse({ success: true }); // 성공적으로 사이드 패널을 열었음을 응답
     } catch (error) {
       console.error("Error in open_sidepanel:", error);
+      sendResponse({ success: false, error: error.message });
     }
   } else if (request.action === "eezy") {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -120,9 +114,8 @@ chrome.runtime.onMessage.addListener(async (request) => {
             func: extractHtml,
           },
           (results) => {
-            if (results) {
+            if (results && results[0]) {
               const extractedContent = results[0].result;
-              console.log("Extracted HTML Content:", extractedContent);
 
               // Send the extracted content to the API
               fetch("http://13.124.143.64/api/eezy/", {
@@ -138,18 +131,27 @@ chrome.runtime.onMessage.addListener(async (request) => {
                 }),
               })
                 .then((response) => response.json())
-                .then((data) => console.log("Response from API:", data))
-                .catch((error) =>
-                  console.error("Error sending data to API:", error)
-                );
+                .then((data) => {
+                  sendResponse({ response: data });
+                })
+                .catch((error) => {
+                  console.error("Error sending data to API:", error);
+                  sendResponse({ response: "error" });
+                });
+            } else {
+              console.log("No results from script execution.");
+              sendResponse({ response: "no results" });
             }
           }
         );
       } else {
         console.log("활성화된 탭을 찾을 수 없습니다.");
+        sendResponse({ response: "no active tab" });
       }
     });
+    return true; // 비동기 응답을 허용
   }
+  return true;
 });
 
 // 만약 열어놨던 chat gpt 탭이나 landing.html 탭이 닫히면 사이드 패널도 닫히도록 함

--- a/src/components/common/TypeAnimation.jsx
+++ b/src/components/common/TypeAnimation.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from "react";
+
+export const TypeAnimation = ({ text, frame, setFlag, startTime = 0 }) => {
+  const [typeText, setTypeText] = useState("");
+  const textIndex = useRef(0);
+  const lastTimeStamp = useRef(null);
+
+  const animationCallback = (timeStamp) => {
+    if (lastTimeStamp.current === null) {
+      lastTimeStamp.current = timeStamp;
+    }
+
+    const elapsedTime = timeStamp - lastTimeStamp.current;
+
+    // timeStamp를 측정해서, frame만큼 시간이 지날 경우 코드를 실행
+    if (elapsedTime > frame) {
+      lastTimeStamp.current = timeStamp;
+      setTypeText((state) => {
+        const newState = state + text[textIndex.current];
+        textIndex.current += 1;
+        return newState;
+      });
+    }
+
+    if (textIndex.current >= text.length) {
+      if (setFlag !== undefined) setFlag(false);
+      return;
+    }
+    requestAnimationFrame(animationCallback);
+  };
+
+  const delayAnimation = (timestamp) => {
+    if (lastTimeStamp.current === null) {
+      lastTimeStamp.current = timestamp;
+    }
+
+    const elapsedTime = timestamp - lastTimeStamp.current;
+
+    if (elapsedTime > startTime) {
+      lastTimeStamp.current = null;
+      requestAnimationFrame(animationCallback);
+    } else {
+      requestAnimationFrame(delayAnimation);
+    }
+  };
+
+  useEffect(() => {
+    let animatedId = requestAnimationFrame(delayAnimation);
+
+    return () => cancelAnimationFrame(animatedId);
+  }, [text]);
+
+  const formattedText = typeText.length >= 1 && typeText.split('\n').map((line, index) => (
+    <span key={index}>
+      {line}
+      {index < text.split('\n').length - 1 && <br />}
+    </span>
+  ));
+
+  return <>{formattedText}</>;
+};

--- a/src/components/eezy/EezyItem.jsx
+++ b/src/components/eezy/EezyItem.jsx
@@ -1,18 +1,27 @@
+//import styled
 import styled from "styled-components";
+//import img
 import Eezy from "@assets/icon/icon-eezy--small.svg?react";
 import Edit from "@assets/icon/icon-edit.svg?react";
-import { EezyButton } from "./EezyButton";
 import Copy from "@assets/icon/icon-copy.svg?react";
 import Regenerate from "@assets/icon/icon-refresh.svg?react";
 import Share from "@assets/icon/icon-share.svg?react";
+//import components
+import { TypeAnimation } from "../common/TypeAnimation";
+import { EezyButton } from "./EezyButton";
 
-export const EezyItem = ({ data = { title: "Exporing UI Design" } }) => {
+export const EezyItem = ({ isLoading = true, setLoading, data }) => {
+  const subTitle = data.content ? data.content.split("\n")[0].slice(2) : undefined;
+  const content = data.content
+    ? data.content.split("\n").slice(2).join("\n")
+    : undefined;
+
   return (
     <Container>
       <Header>
         <Title>
           <Eezy />
-          <span>{data.title}</span>
+          {<TypeAnimation text={data.title} frame={50} />}
         </Title>
         <div>
           <Edit width={13} height={13} />
@@ -20,39 +29,30 @@ export const EezyItem = ({ data = { title: "Exporing UI Design" } }) => {
       </Header>
       <Contents>
         <Content>
-          <span>SubTitle1</span>
+          {<TypeAnimation text={subTitle} frame={50} startTime={1200} />}
           <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting
-            industry. Lorem Ipsum has been the industry's standard dummy text
-            ever since the 1500s, when an unknown printer took a galley of type
-            and scrambled it to make a type specimen book. It has survived not
-            only five centuries, but also the leap into electronic typesetting,
-            remaining essentially unchanged. It was popularised in the 1960s
-            with the release of Letraset sheets containing Lorem Ipsum passages,
-            and more recently with desktop publishing software like Aldus
-            PageMaker including versions of Lorem Ipsum.
-          </div>
-        </Content>
-        <Content>
-          <span>SubTitle2</span>
-          <div>
-            Lorem Ipsum is simply dummy text of the printing and typesetting
-            industry. Lorem Ipsum has been the industry's standard dummy text
-            ever since the 1500s, when an unknown printer took a galley of type
-            and scrambled it to make a type specimen book. It has survived not
-            only five centuries, but also the leap into electronic typesetting,
-            remaining essentially unchanged. It was popularised in the 1960s
-            with the release of Letraset sheets containing Lorem Ipsum passages,
-            and more recently with desktop publishing software like Aldus
-            PageMaker including versions of Lorem Ipsum.
+            {
+              <TypeAnimation
+                text={content}
+                frame={10}
+                startTime={2000}
+                setFlag={setLoading}
+              />
+            }
           </div>
         </Content>
       </Contents>
-      <Buttons>
-        <EezyButton text="Copy" Img={Copy} onclickFunc={() => {}} />
-        <EezyButton text="Regenerate" Img={Regenerate} onclickFunc={() => {}} />
-        <EezyButton text="Share" Img={Share} onclickFunc={() => {}} />
-      </Buttons>
+      {!isLoading && (
+        <Buttons>
+          <EezyButton text="Copy" Img={Copy} onclickFunc={() => {}} />
+          <EezyButton
+            text="Regenerate"
+            Img={Regenerate}
+            onclickFunc={() => {}}
+          />
+          <EezyButton text="Share" Img={Share} onclickFunc={() => {}} />
+        </Buttons>
+      )}
     </Container>
   );
 };
@@ -84,7 +84,7 @@ const Title = styled.div`
   }
 `;
 const Contents = styled.div`
-  height: 304px;
+  max-height: 304px;
 
   display: flex;
   flex-direction: column;

--- a/src/pages/EezingPage.jsx
+++ b/src/pages/EezingPage.jsx
@@ -1,12 +1,16 @@
+import { useState, useEffect } from "react";
+// import styled
 import styled from "styled-components";
+// import img
 import Logo from "@assets/icon/icon-logo--img.svg?react";
 import Folder from "@assets/icon/icon-folder.svg?react";
+// import components
 import { EezyItem } from "@components/eezy/EezyItem";
-import { useState, useEffect } from "react";
 
 export const EezingPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [loadingCount, setLoadingCount] = useState(1);
+  const [data, setData] = useState({});
 
   useEffect(() => {
     let timer;
@@ -21,17 +25,20 @@ export const EezingPage = () => {
   useEffect(() => {
     const fetchEezy = async () => {
       try {
-        const response = await chrome.runtime.sendMessage(
-          { action: "eezy" },
-          (response) => {
-            console.log(response);
-          }
-        );
+        const { response } = await new Promise((resolve, reject) => {
+          chrome.runtime.sendMessage({ action: "eezy" }, (response) => {
+            if (chrome.runtime.lastError) {
+              reject(chrome.runtime.lastError);
+            } else {
+              resolve(response);
+            }
+          });
+        });
+        setData(response); // 성공 시 typing animation 실행
       } catch (error) {
         console.error("Error sending message:", error);
       }
     };
-
     fetchEezy();
   }, []);
 
@@ -45,26 +52,32 @@ export const EezingPage = () => {
           {isLoading ? `eezing${".".repeat(loadingCount)}` : "Complete!"}
         </span>
       </Header>
-      <EezyItem />
-      <MemoBox>
-        <MemoInput type="text" placeholder="Add memo..." />
-        <MemoNum>
-          <span>0/500</span>
-        </MemoNum>
-      </MemoBox>
-      <AddBox>
-        <AddButton>Add your History</AddButton>
-      </AddBox>
-      <ChooseBox>
-        <ChooseText>
-          <span>Related Category</span>
-          <span>or create new category</span>
-        </ChooseText>
-        <ChooseIcon>
-          <span>+1</span>
-          <Folder width={15} height={11} />
-        </ChooseIcon>
-      </ChooseBox>
+      <EezyItem isLoading={isLoading} setLoading={setIsLoading} data={data} />
+      {!isLoading && (
+        <MemoBox>
+          <MemoInput type="text" placeholder="Add memo..." />
+          <MemoNum>
+            <span>0/500</span>
+          </MemoNum>
+        </MemoBox>
+      )}
+      {!isLoading && (
+        <AddBox>
+          <AddButton>Add your History</AddButton>
+        </AddBox>
+      )}
+      {!isLoading && (
+        <ChooseBox>
+          <ChooseText>
+            <span>Related Category</span>
+            <span>or create new category</span>
+          </ChooseText>
+          <ChooseIcon>
+            <span>+1</span>
+            <Folder width={15} height={11} />
+          </ChooseIcon>
+        </ChooseBox>
+      )}
     </Container>
   );
 };

--- a/src/pages/EezingPage.jsx
+++ b/src/pages/EezingPage.jsx
@@ -2,15 +2,48 @@ import styled from "styled-components";
 import Logo from "@assets/icon/icon-logo--img.svg?react";
 import Folder from "@assets/icon/icon-folder.svg?react";
 import { EezyItem } from "@components/eezy/EezyItem";
+import { useState, useEffect } from "react";
 
 export const EezingPage = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadingCount, setLoadingCount] = useState(1);
+
+  useEffect(() => {
+    let timer;
+    if (isLoading) {
+      timer = setTimeout(() => {
+        setLoadingCount((prevCount) => (prevCount < 3 ? prevCount + 1 : 1));
+      }, 1000);
+    }
+    return () => clearTimeout(timer);
+  }, [loadingCount, isLoading]);
+
+  useEffect(() => {
+    const fetchEezy = async () => {
+      try {
+        const response = await chrome.runtime.sendMessage(
+          { action: "eezy" },
+          (response) => {
+            console.log(response);
+          }
+        );
+      } catch (error) {
+        console.error("Error sending message:", error);
+      }
+    };
+
+    fetchEezy();
+  }, []);
+
   return (
     <Container>
       <Header>
         <ProfileCircle>
           <Logo width={20} height={20} />
         </ProfileCircle>
-        <span>eezing...</span>
+        <span>
+          {isLoading ? `eezing${".".repeat(loadingCount)}` : "Complete!"}
+        </span>
       </Header>
       <EezyItem />
       <MemoBox>
@@ -88,7 +121,8 @@ const MemoInput = styled.textarea`
   &::placeholder {
     color: rgba(0, 0, 0, 0.45);
   }
-  &:active, &:focus {
+  &:active,
+  &:focus {
     outline: none;
   }
 `;

--- a/src/pages/EezyPage.jsx
+++ b/src/pages/EezyPage.jsx
@@ -8,13 +8,6 @@ export const EezyPage = () => {
   const navigate = useNavigate();
 
   const handleEezyClick = () => {
-    chrome.runtime.sendMessage({ action: "eezy" }, (response) => {
-      if (chrome.runtime.lastError) {
-        console.error("Error sending message:", chrome.runtime.lastError);
-      } else {
-        console.log("Message sent successfully:", response);
-      }
-    });
     navigate("/eezy/eezying");
   };
 


### PR DESCRIPTION
## What
이 pr은 Eezy API를 통한 페이지 요약을 구현한 화면입니다.
아래의 변경 사항을 포함합니다.

-  TypeAnimation을 통해 데이터를 타이핑해서 렌더
- background js <-> client 상호 통신
- eezy... -> complete! 내용 변경
- 데이터 모두 렌더 이후 하단 버튼 생성

## Why
API를 background에서 전달받아 client로 재전송하는 과정에서 delay과정을 처리하기 위해

## How to Test
1. npm run build
2. [크롬 확장 프로그램](chrome://extensions/)에서 dist 폴더 로드
3. 익스텐션 아이콘 클릭
4. 팝업의 eezy 클릭
5. Eezy버튼 클릭


## Screenshots

<img width="586" alt="스크린샷 2024-11-11 오후 1 08 19" src="https://github.com/user-attachments/assets/eaf626e0-1b24-4d7a-8ee3-12cc4ac17f66">


## Additional Information
- 하단 버튼의 모든 사용자 메모 기능, 복사 기능, 재 생성, 공유 기능은 구현하지 않았습니다.
