### PR TITLE
Feat/capture

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -93,11 +93,24 @@ function extractHtml() {
 }
 
 // 팝업의 버튼이 눌렸을 때의 preview.jsx/onSqueeze()의 메시지를 수신하기 위한 이벤트 리스너 등록
-chrome.runtime.onMessage.addListener(async (request) => {
+chrome.runtime.onMessage.addListener((request, send, sendResponse) => {
+  if (request.action === "preview") {
+    (async function () {
+      try {
+        await previewTab((previews) => {
+          sendResponse(previews);
+        });
+      } catch (error) {
+        sendResponse({});
+      }
+    })();
+    return true;
+  }
+
   if (request.action === "open_sidepanel") {
     try {
       if (request.type) {
-        await chrome.storage.local.set({ type: request.type });
+        chrome.storage.local.set({ type: request.type });
       }
       /*
       if (!homeAndGptWindow) {
@@ -213,3 +226,50 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     return true;
   }
 });
+
+function previewTab(callback) {
+  const previews = {
+    titles: [],
+    urls: [],
+    favicons: [],
+    capturedImage: "",
+  };
+  chrome.tabs.query({}, (tabs) => {
+    tabs.forEach((tab, index) => {
+      if (index > 0 && index != tab.index) return; // 현재 탭만 허용
+      previews.titles.push(tab.title);
+      previews.urls.push(tab.url);
+      previews.favicons.push(tab.favIconUrl);
+    });
+    
+    chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
+      if (dataUrl) {
+        previews.capturedImage = dataUrl;
+        callback(previews);
+      } else {
+        captureTab(previews, 0, tabs, callback); // 캡처 실패 시 모든 탭 재귀형 캡처
+      }
+    }); // 현재 탭 캡쳐
+  });
+}
+
+function captureTab(previews, index, tabs, callback) {
+  if (index >= tabs.length) {
+    callback(previews);
+    return;
+  }
+
+  const tab = tabs[index];
+  chrome.tabs.update(tab.id, { active: true }, () => {
+    setTimeout(() => {
+      chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
+        if (dataUrl) {
+          previews.capturedImage = dataUrl; // 캡처 성공
+          callback(previews);
+        } else {
+          captureTab(previews, index + 1, tabs, callback);
+        }
+      });
+    }, 700); // 1초 대기 후 캡처 시도
+  });
+}

--- a/src/pages/SqueezingPage.jsx
+++ b/src/pages/SqueezingPage.jsx
@@ -1,8 +1,29 @@
 import styled from "styled-components";
 import Logo from "@assets/icon/icon-logo--img.svg?react";
 import { SqueezeItem } from "../components/squeeze/SqueezeItem";
+import { useEffect, useState } from "react";
 
 export const SqueezingPage = () => {
+  const [tabsData, setTabsData] = useState({
+    titles: [],
+    urls: [],
+    favicons: [],
+    capturedImage: "",
+  });
+
+  useEffect(() => {
+    const getTabsData = async () => {
+      await new Promise((resolve, reject) => {
+        chrome.runtime.sendMessage({ action: "preview" }, (response) => {
+          if (response) resolve(response);
+        });
+      }).then((res) => {
+        setTabsData(res);
+      });
+    };
+    getTabsData();
+  }, []);
+
   return (
     <Container>
       <Header>
@@ -51,4 +72,3 @@ const ProfileCircle = styled.div`
   justify-content: center;
   align-items: center;
 `;
-


### PR DESCRIPTION
## What
해당 PR은 background.js를 통해 squeezing에 필요한 탭 정보들을 받아옵니다. 
- preview 이벤트 background에 전송
- background는 이벤트 확인 후 squeezing에 필요한 데이터 제공

## Why
chrome tabs에 대한 정보를 background로부터 비동기로 받아와야함

## How to Test
1. squeezing 메뉴 클릭
2. squeezing 페이지 확인

## Screenshots
<img width="948" alt="image" src="https://github.com/user-attachments/assets/8b222148-780e-4edf-a179-32a24e89dd56">

## Additional Information
...
