### PR TITLE
fix : api 제공 형식에 맞춰서 previews 구조 변경

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -263,17 +263,17 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 function previewTab(callback) {
   const previews = {
-    titles: [],
-    urls: [],
-    favicons: [],
+    tabs : [],
     capturedImage: "",
   };
   chrome.tabs.query({}, (tabs) => {
     tabs.forEach((tab, index) => {
       if (index > 0 && index != tab.index) return; // 현재 탭만 허용
-      previews.titles.push(tab.title);
-      previews.urls.push(tab.url);
-      previews.favicons.push(tab.favIconUrl);
+      previews.tabs.push({
+        title : tab.title,
+        url : tab.url,
+        favicon : tab.favIconUrl,
+      })
     });
     
     chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {

--- a/src/pages/SqueezingPage.jsx
+++ b/src/pages/SqueezingPage.jsx
@@ -5,10 +5,8 @@ import { useEffect, useState } from "react";
 
 export const SqueezingPage = () => {
   const [tabsData, setTabsData] = useState({
-    titles: [],
-    urls: [],
-    favicons: [],
-    capturedImage: "",
+    tabs : [],
+    capturedImage : "",
   });
 
   useEffect(() => {


### PR DESCRIPTION
## What
해당 PR은 background.js를 통해 squeezing에 필요한 탭 정보들을 받아옵니다.  <- 탭정보 제공 구조 변경
- preview 이벤트 background에 전송 <- previews 구조 squeeze api에 맞게 변경

## Why
api에 맞게 받아와야 제공할 때 별도의 데이터 처리과정을 수행하지 않음

## How to Test
1. squeezing 메뉴 클릭
2. squeezing 페이지 확인

## Screenshots
<img width="948" alt="image" src="https://github.com/user-attachments/assets/8b222148-780e-4edf-a179-32a24e89dd56">

## Additional Information
...
