### PR TITLE
Feat/search page 히스토리 컴포넌트

### DIFF
--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -1,11 +1,35 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
+
+const Content = () => {
+  return (
+    <Comp>
+      <ContentImg src="https://dummyimage.com/50x50/d9d9d9/000000" />
+      <TextBox>
+        <Title>SUPER VERY MORE - AESPA EP.3 Don't you know I'm a Savage?</Title>
+        <Url>https://superverymore.tv/aespa-ep3-dont-you-know...</Url>
+      </TextBox>
+    </Comp>
+  );
+};
 
 export const SearchPage = () => {
   const [keyword, setKeyword] = useState("");
+  const [history, setHistory] = useState([]);
+
   const onChange = (event) => {
     setKeyword(event.target.value);
   };
+
+  const getHistory = async () => {
+    const json = await (await fetch(`http://13.124.143.64/api/users/profile/`)).json();
+    setHistory(json);
+    alert(history);
+  };
+
+  useEffect(() => {
+    getHistory();
+  }, []);
 
   return (
     <>
@@ -14,14 +38,51 @@ export const SearchPage = () => {
       </Container>
       <AppWrapper>
         <SearchBar type="text" value={keyword} onChange={onChange} placeholder="Keywords," />
+        {/* <Content /> */}
       </AppWrapper>
     </>
   );
 };
 
+const Comp = styled.div`
+  width: 335px;
+  height: 50px;
+  margin-top: 18px;
+  display: flex;
+  flex-direction: row;
+  border: 1px red solid;
+`;
+
+const TextBox = styled.div`
+  width: 273px;
+  height: 50px;
+  margin-left: 12px;
+  border: 1px blue solid;
+`;
+
+const Title = styled.div`
+  height: 32px;
+  border: 1px seagreen solid;
+  ${(props) => props.theme.typography.h3};
+  color: ${(props) => props.theme.color.black};
+`;
+
+const Url = styled.div`
+  height: 14px;
+  margin-top: 4px;
+  border: 1px dodgerblue solid;
+  ${(props) => props.theme.typography.subDescription};
+  color: #858585;
+`;
+
+const ContentImg = styled.img`
+  width: 50px;
+  height: 50px;
+  border-radius: 8px;
+`;
+
 const Container = styled.div`
   padding: 9px 14px;
-
   display: flex;
   flex-direction: column;
 `;
@@ -33,7 +94,9 @@ const Header = styled.header`
 
 const AppWrapper = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
 `;
 
 const SearchBar = styled.input`

--- a/src/pages/SearchPage.jsx
+++ b/src/pages/SearchPage.jsx
@@ -50,19 +50,16 @@ const Comp = styled.div`
   margin-top: 18px;
   display: flex;
   flex-direction: row;
-  border: 1px red solid;
 `;
 
 const TextBox = styled.div`
   width: 273px;
   height: 50px;
   margin-left: 12px;
-  border: 1px blue solid;
 `;
 
 const Title = styled.div`
   height: 32px;
-  border: 1px seagreen solid;
   ${(props) => props.theme.typography.h3};
   color: ${(props) => props.theme.color.black};
 `;
@@ -70,7 +67,6 @@ const Title = styled.div`
 const Url = styled.div`
   height: 14px;
   margin-top: 4px;
-  border: 1px dodgerblue solid;
   ${(props) => props.theme.typography.subDescription};
   color: #858585;
 `;


### PR DESCRIPTION
## What
검색 페이지의 UI에 포함되는 eezy, squeezy 히스토리 컴포넌트입니다.
백엔드와 연동이 되어 있지 않습니다.

## Why

## How to Test
1. npm run build
2. 크롬 확장 프로그램에서 dist 폴더 로드
3. 익스텐션 아이콘 클릭
4. 팝업의 squeeze or eezy 클릭
5. 선택된 타입에 해당하는 슬라이드가 열리는 지 확인
6. 메뉴 아이콘 클릭
7. search 메뉴 클릭

## Screenshots
![스크린샷 2024-11-17 011806](https://github.com/user-attachments/assets/a2b0979c-4430-4cbe-98db-5663add8ae86)
border은 해제되어 있습니다.

## Additional Information